### PR TITLE
Refactor: Add explicit StringComparison to string comparison methods

### DIFF
--- a/src/Tizen.NUI/src/internal/XamlBinding/BindingExpression.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/BindingExpression.cs
@@ -387,7 +387,7 @@ namespace Tizen.NUI.Binding
 #if NETSTANDARD1_0
                                 foreach (MethodInfo m in sourceType.AsType().GetRuntimeMethods())
                                 {
-                                    if (m.Name.EndsWith("IElementController.SetValueFromRenderer"))
+                                    if (m.Name.EndsWith("IElementController.SetValueFromRenderer", StringComparison.Ordinal))
                                     {
                                         ParameterInfo[] parameters = m.GetParameters();
                                         if (parameters.Length == 2 && parameters[0].ParameterType == typeof(BindableProperty))
@@ -454,7 +454,7 @@ namespace Tizen.NUI.Binding
                 var stringValue = value as string ?? string.Empty;
                 // see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
                 // do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
-                if (stringValue.EndsWith(".") && DecimalTypes.Contains(convertTo))
+                if (stringValue.EndsWith(".", StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
                     throw new FormatException();
 
                 // do not canonicalize "-0"; user will likely enter a period after "-0"

--- a/src/Tizen.NUI/src/internal/XamlBinding/TizenPlatformServices.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/TizenPlatformServices.cs
@@ -153,7 +153,7 @@ namespace Tizen.NUI.Binding
 
                 foreach (var refName in asm.GetReferencedAssemblies())
                 {
-                    if (!refName.Name.StartsWith("System.") && !refName.Name.StartsWith("Microsoft.") && !refName.Name.StartsWith("mscorlib"))
+                    if (!refName.Name.StartsWith("System.", StringComparison.Ordinal) && !refName.Name.StartsWith("Microsoft.", StringComparison.Ordinal) && !refName.Name.StartsWith("mscorlib", StringComparison.Ordinal))
                     {
                         try
                         {

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -110,7 +110,7 @@ namespace Tizen.NUI.BaseComponents
         private static string ConvertResourceUrl(ref string value)
         {
             value ??= "";
-            if (value.StartsWith("*Resource*"))
+            if (value.StartsWith("*Resource*", StringComparison.Ordinal))
             {
                 string resource = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
                 value = value.Replace("*Resource*", resource);
@@ -578,7 +578,7 @@ namespace Tizen.NUI.BaseComponents
                         ret = urlValue.Get(out url);
                     }
                     using PropertyMap mmap = new PropertyMap();
-                    if (ret && url.StartsWith("*Resource*"))
+                    if (ret && url.StartsWith("*Resource*", StringComparison.Ordinal))
                     {
                         url = url.Replace("*Resource*", resource);
                         using var pv = new PropertyValue(url);
@@ -591,7 +591,7 @@ namespace Tizen.NUI.BaseComponents
                     {
                         ret = alphaMaskUrlValue.Get(out alphaMaskURL);
                     }
-                    if (ret && alphaMaskURL.StartsWith("*Resource*"))
+                    if (ret && alphaMaskURL.StartsWith("*Resource*", StringComparison.Ordinal))
                     {
                         alphaMaskURL = alphaMaskURL.Replace("*Resource*", resource);
                         using var pv = new PropertyValue(alphaMaskURL);
@@ -604,7 +604,7 @@ namespace Tizen.NUI.BaseComponents
                     {
                         ret = auxiliaryImageURLValue.Get(out auxiliaryImageURL);
                     }
-                    if (ret && auxiliaryImageURL.StartsWith("*Resource*"))
+                    if (ret && auxiliaryImageURL.StartsWith("*Resource*", StringComparison.Ordinal))
                     {
                         auxiliaryImageURL = auxiliaryImageURL.Replace("*Resource*", resource);
                         using var pv = new PropertyValue(auxiliaryImageURL);
@@ -2654,11 +2654,11 @@ namespace Tizen.NUI.BaseComponents
                 {
                     return true;
                 }
-                if (_resourceUrl.StartsWith("dali://") || _resourceUrl.StartsWith("enbuf://"))
+                if (_resourceUrl.StartsWith("dali://", StringComparison.Ordinal) || _resourceUrl.StartsWith("enbuf://", StringComparison.Ordinal))
                 {
                     return true;
                 }
-                if (!string.IsNullOrEmpty(_alphaMaskUrl) && (_alphaMaskUrl.StartsWith("dali://") || _alphaMaskUrl.StartsWith("enbuf://")))
+                if (!string.IsNullOrEmpty(_alphaMaskUrl) && (_alphaMaskUrl.StartsWith("dali://", StringComparison.Ordinal) || _alphaMaskUrl.StartsWith("enbuf://", StringComparison.Ordinal)))
                 {
                     return true;
                 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -939,11 +939,11 @@ namespace Tizen.NUI.BaseComponents
                 return HorizontalAlignment.Begin; // Return default value.
             }
 
-            if (temp.Equals("BEGIN"))
+            if (temp.Equals("BEGIN", StringComparison.Ordinal))
             {
                 return HorizontalAlignment.Begin;
             }
-            else if (temp.Equals("CENTER"))
+            else if (temp.Equals("CENTER", StringComparison.Ordinal))
             {
                 return HorizontalAlignment.Center;
             }
@@ -998,11 +998,11 @@ namespace Tizen.NUI.BaseComponents
                 return VerticalAlignment.Top; // Return default value.
             }
 
-            if (temp.Equals("TOP"))
+            if (temp.Equals("TOP", StringComparison.Ordinal))
             {
                 return VerticalAlignment.Top;
             }
-            else if (temp.Equals("CENTER"))
+            else if (temp.Equals("CENTER", StringComparison.Ordinal))
             {
                 return VerticalAlignment.Center;
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2174,7 +2174,7 @@ namespace Tizen.NUI.BaseComponents
                 return;
             }
 
-            if (value.StartsWith("*Resource*"))
+            if (value.StartsWith("*Resource*", StringComparison.Ordinal))
             {
                 string resource = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
                 value = value.Replace("*Resource*", resource);

--- a/src/Tizen.NUI/src/public/Common/Color.cs
+++ b/src/Tizen.NUI/src/public/Common/Color.cs
@@ -1005,8 +1005,8 @@ namespace Tizen.NUI
                 }
                 else // example rgb(255,255,255) or rgb(255,255,255,1.0)
                 {
-                    bool isRGBA = textColor.StartsWith("RGBA(");
-                    bool isRGB = textColor.StartsWith("RGB(");
+                    bool isRGBA = textColor.StartsWith("RGBA(", StringComparison.Ordinal);
+                    bool isRGB = textColor.StartsWith("RGB(", StringComparison.Ordinal);
 
                     if (!isRGBA && !isRGB)
                     {

--- a/src/Tizen.NUI/src/public/Utility/DpTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/Utility/DpTypeConverter.cs
@@ -59,11 +59,11 @@ namespace Tizen.NUI
             float convertedValue = 0;
             if (scriptValue != null)
             {
-                if (scriptValue.EndsWith("dp"))
+                if (scriptValue.EndsWith("dp", StringComparison.Ordinal))
                 {
                     convertedValue = ConvertToPixel(float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("dp")), CultureInfo.InvariantCulture));
                 }
-                else if (scriptValue.EndsWith("px"))
+                else if (scriptValue.EndsWith("px", StringComparison.Ordinal))
                 {
                     convertedValue = float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("px")), CultureInfo.InvariantCulture);
                 }

--- a/src/Tizen.NUI/src/public/Utility/GraphicsTypeManager.cs
+++ b/src/Tizen.NUI/src/public/Utility/GraphicsTypeManager.cs
@@ -288,27 +288,27 @@ namespace Tizen.NUI
             float convertedValue = 0;
             if (scriptValue != null)
             {
-                if (scriptValue.EndsWith("dp"))
+                if (scriptValue.EndsWith("dp", StringComparison.Ordinal))
                 {
                     convertedValue = Dp.ConvertScriptToPixel(scriptValue);
                 }
-                else if (scriptValue.EndsWith("sp"))
+                else if (scriptValue.EndsWith("sp", StringComparison.Ordinal))
                 {
                     convertedValue = Sp.ConvertScriptToPixel(scriptValue);
                 }
-                else if (scriptValue.EndsWith("sdp"))
+                else if (scriptValue.EndsWith("sdp", StringComparison.Ordinal))
                 {
                     convertedValue = Sdp.ConvertScriptToPixel(scriptValue);
                 }
-                else if (scriptValue.EndsWith("pt"))
+                else if (scriptValue.EndsWith("pt", StringComparison.Ordinal))
                 {
                     convertedValue = Point.ConvertScriptToPixel(scriptValue);
                 }
-                else if (scriptValue.EndsWith("spx"))
+                else if (scriptValue.EndsWith("spx", StringComparison.Ordinal))
                 {
                     convertedValue = scalingFactor * float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("spx")), CultureInfo.InvariantCulture);
                 }
-                else if (scriptValue.EndsWith("px"))
+                else if (scriptValue.EndsWith("px", StringComparison.Ordinal))
                 {
                     convertedValue = float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("px")), CultureInfo.InvariantCulture);
                 }

--- a/src/Tizen.NUI/src/public/Utility/PointTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/Utility/PointTypeConverter.cs
@@ -62,11 +62,11 @@ namespace Tizen.NUI
             float convertedValue = 0;
             if (scriptValue != null)
             {
-                if (scriptValue.EndsWith("pt"))
+                if (scriptValue.EndsWith("pt", StringComparison.Ordinal))
                 {
                     convertedValue = ConvertToPixel(float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("pt")), CultureInfo.InvariantCulture));
                 }
-                else if (scriptValue.EndsWith("px"))
+                else if (scriptValue.EndsWith("px", StringComparison.Ordinal))
                 {
                     convertedValue = float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("px")), CultureInfo.InvariantCulture);
                 }
@@ -93,19 +93,19 @@ namespace Tizen.NUI
             float convertedValue = 0;
             if (scriptValue != null)
             {
-                if (scriptValue.EndsWith("sp"))
+                if (scriptValue.EndsWith("sp", StringComparison.Ordinal))
                 {
                     convertedValue = ConvertSpToPoint(float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("sp")), CultureInfo.InvariantCulture));
                 }
-                else if (scriptValue.EndsWith("sdp"))
+                else if (scriptValue.EndsWith("sdp", StringComparison.Ordinal))
                 {
                     convertedValue = ConvertSdpToPoint(float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("sdp")), CultureInfo.InvariantCulture));
                 }
-                else if (scriptValue.EndsWith("dp"))
+                else if (scriptValue.EndsWith("dp", StringComparison.Ordinal))
                 {
                     convertedValue = ConvertDpToPoint(float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("dp")), CultureInfo.InvariantCulture));
                 }
-                else if (scriptValue.EndsWith("pt"))
+                else if (scriptValue.EndsWith("pt", StringComparison.Ordinal))
                 {
                     convertedValue = float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("px")), CultureInfo.InvariantCulture);
                 }

--- a/src/Tizen.NUI/src/public/Utility/SdpTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/Utility/SdpTypeConverter.cs
@@ -59,7 +59,7 @@ namespace Tizen.NUI
             float convertedValue = 0;
             if (scriptValue != null)
             {
-                if (scriptValue.EndsWith("sdp"))
+                if (scriptValue.EndsWith("sdp", StringComparison.Ordinal))
                 {
                     convertedValue = ConvertToPixel(float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("sdp")), CultureInfo.InvariantCulture));
                 }

--- a/src/Tizen.NUI/src/public/Utility/SpTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/Utility/SpTypeConverter.cs
@@ -63,7 +63,7 @@ namespace Tizen.NUI
             float convertedValue = 0;
             if (scriptValue != null)
             {
-                if (scriptValue.EndsWith("sp"))
+                if (scriptValue.EndsWith("sp", StringComparison.Ordinal))
                 {
                     convertedValue = ConvertToPixel(float.Parse(scriptValue.Substring(0, scriptValue.LastIndexOf("sp")), CultureInfo.InvariantCulture));
                 }

--- a/src/Tizen.NUI/src/public/ViewProperty/ImageShadow.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/ImageShadow.cs
@@ -170,7 +170,7 @@ namespace Tizen.NUI
             map.Set(ImageVisualProperty.Border, Border);
 
             string urlString = Url;
-            if (Url.StartsWith("*Resource*"))
+            if (Url.StartsWith("*Resource*", StringComparison.Ordinal))
             {
                 string resource = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
                 urlString = Url.Replace("*Resource*", resource);

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
@@ -655,11 +655,11 @@ namespace Tizen.NUI.Visuals
                 {
                     return true;
                 }
-                if (ResourceUrl.StartsWith("dali://") || ResourceUrl.StartsWith("enbuf://"))
+                if (ResourceUrl.StartsWith("dali://", StringComparison.Ordinal) || ResourceUrl.StartsWith("enbuf://", StringComparison.Ordinal))
                 {
                     return true;
                 }
-                if (!string.IsNullOrEmpty(AlphaMaskUrl) && (AlphaMaskUrl.StartsWith("dali://") || AlphaMaskUrl.StartsWith("enbuf://")))
+                if (!string.IsNullOrEmpty(AlphaMaskUrl) && (AlphaMaskUrl.StartsWith("dali://", StringComparison.Ordinal) || AlphaMaskUrl.StartsWith("enbuf://", StringComparison.Ordinal)))
                 {
                     return true;
                 }

--- a/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarDatabase.cs
+++ b/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarDatabase.cs
@@ -384,15 +384,15 @@ namespace Tizen.Pims.Calendar
                 record = list.GetCurrentRecord();
                 if (0 == propertyId)
                 {
-                    if (0 == String.Compare(CalendarViews.Book.Uri, record.Uri))
+                    if (CalendarViews.Book.Uri.Equals(record.Uri, StringComparison.Ordinal))
                         propertyId = CalendarViews.Book.Id;
-                    else if (0 == String.Compare(CalendarViews.Event.Uri, record.Uri))
+                    else if (CalendarViews.Event.Uri.Equals(record.Uri, StringComparison.Ordinal))
                         propertyId = CalendarViews.Event.Id;
-                    else if (0 == String.Compare(CalendarViews.Todo.Uri, record.Uri))
+                    else if (CalendarViews.Todo.Uri.Equals(record.Uri, StringComparison.Ordinal))
                         propertyId = CalendarViews.Todo.Id;
-                    else if (0 == String.Compare(CalendarViews.Timezone.Uri, record.Uri))
+                    else if (CalendarViews.Timezone.Uri.Equals(record.Uri, StringComparison.Ordinal))
                         propertyId = CalendarViews.Timezone.Id;
-                    else if (0 == String.Compare(CalendarViews.Extended.Uri, record.Uri))
+                    else if (CalendarViews.Extended.Uri.Equals(record.Uri, StringComparison.Ordinal))
                         propertyId = CalendarViews.Extended.Id;
                     else
                     {


### PR DESCRIPTION
## Summary

This PR adds explicit `StringComparison.Ordinal` arguments to string comparison methods that were previously using the default culture-sensitive behavior. The changes span 14 files across `Tizen.NUI` and `Tizen.Pims.Calendar`.

## Background

Several .NET string methods use `CurrentCulture` when no `StringComparison` is specified:

| Method | Default (no arg) |
|--------|-----------------|
| `String.Compare(a, b)` | `CurrentCulture` ⚠️ |
| `.StartsWith(string)` | `CurrentCulture` ⚠️ |
| `.EndsWith(string)` | `CurrentCulture` ⚠️ |
| `.IndexOf(string)` | `CurrentCulture` ⚠️ |
| `.Equals(string)` | `Ordinal` ✅ |
| `.Contains(string)` | `Ordinal` (.NET 5+) ✅ |

Since TizenFX runs on global devices (including Turkish, Arabic, German locales), relying on `CurrentCulture` for internal symbol/protocol/format string comparisons can cause subtle, hard-to-reproduce bugs — most famously the **"Turkish I problem"** where case-insensitive culture comparisons yield unexpected results.

This is also flagged by FxCop rules **CA1307** and **CA1309**.

## Changes

### `Tizen.Pims.Calendar` — 5 changes
**`CalendarDatabase.cs`**
- `String.Compare(CalendarViews.*.Uri, record.Uri) == 0` → `.Equals(record.Uri, StringComparison.Ordinal)`
- URI strings such as `"tizen.calendar/book"` are internal ASCII constants; `String.Compare` without `StringComparison` defaults to `CurrentCulture`.

### `Tizen.NUI` — 35 changes

**`BaseComponents/ImageView.cs`** (6 changes)
- `StartsWith("*Resource*")` → `StartsWith("*Resource*", StringComparison.Ordinal)` — resource URL marker
- `StartsWith("dali://")` / `StartsWith("enbuf://")` → Ordinal — internal DALi protocol prefixes

**`ViewProperty/ImageShadow.cs`** (1 change)
- `StartsWith("*Resource*")` → Ordinal

**`BaseComponents/ViewBindableProperty.cs`** (1 change)
- `StartsWith("*Resource*")` → Ordinal

**`Visuals/VisualObject/ImageVisual.cs`** (2 changes)
- `StartsWith("dali://")` / `StartsWith("enbuf://")` → Ordinal

**`Common/Color.cs`** (2 changes)
- `StartsWith("RGBA(")` / `StartsWith("RGB(")` → Ordinal — color format string parsing

**`internal/XamlBinding/TizenPlatformServices.cs`** (1 change)
- `StartsWith("System.")` / `StartsWith("Microsoft.")` / `StartsWith("mscorlib")` → Ordinal — assembly name filtering

**`public/Utility/SpTypeConverter.cs`** (1 change)
**`public/Utility/DpTypeConverter.cs`** (2 changes)
**`public/Utility/SdpTypeConverter.cs`** (1 change)
**`public/Utility/PointTypeConverter.cs`** (6 changes)
**`public/Utility/GraphicsTypeManager.cs`** (6 changes)
- Unit suffix matching: `EndsWith("sp")`, `EndsWith("dp")`, `EndsWith("px")`, `EndsWith("sdp")`, `EndsWith("pt")`, `EndsWith("spx")` → Ordinal

**`public/BaseComponents/TextLabel.cs`** (4 changes)
- `Equals("BEGIN")` / `Equals("CENTER")` / `Equals("TOP")` → Ordinal
- Note: `string.Equals(string)` is already Ordinal in .NET 5+; these changes are for explicitness and consistency.

**`internal/XamlBinding/BindingExpression.cs`** (2 changes)
- `EndsWith("IElementController.SetValueFromRenderer")` → Ordinal — method name matching
- `EndsWith(".")` → Ordinal — decimal input validation

## Risk Assessment

All 41 changes carry **no practical risk**:

- Every affected string is a pure ASCII literal (protocol prefixes, unit suffixes, internal symbol names, format tokens).
- `CurrentCulture` and `Ordinal` produce identical results for pure ASCII strings in all locales.
- The `Equals()` changes in `TextLabel.cs` are behaviorally a no-op (instance `Equals` was already Ordinal in .NET 5+).
- No public API signatures are affected — all changes are within `internal`/`private` implementation code.

## Scope

- **Public API contract**: Unchanged
- **Runtime behavior**: Identical across all locales
- **Build**: No new dependencies; `StringComparison` is part of `System` namespace